### PR TITLE
Fix binary.Uvarint overflow. 

### DIFF
--- a/snappy/decode.go
+++ b/snappy/decode.go
@@ -30,6 +30,9 @@ func decodedLen(src []byte) (blockLen, headerLen int, err error) {
 	if n == 0 {
 		return 0, 0, ErrCorrupt
 	}
+	if n < 0 {
+		return 0, 0, errors.New("snappy: value larger than 64 bits (overflow)")
+	}
 	if uint64(int(v)) != v {
 		return 0, 0, errors.New("snappy: decoded block is too large")
 	}


### PR DESCRIPTION
@dvyukov found a bug with his go-fuzz

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/golang/snappy/snappy.Decode(0x0, 0x0, 0x0, 0xc208041f00, 0xa, 0x20, 0x0, 0x0, 0x0, 0x0, ...)
    src/github.com/golang/snappy/snappy/decode.go:54 +0xaca
main.main()
    snappy.go:11 +0xf6

```

More info at https://github.com/golang/snappy/issues/11.