### PR TITLE
Fix max block size check

### DIFF
--- a/snappy_test.go
+++ b/snappy_test.go
@@ -86,6 +86,16 @@ func TestInvalidVarint(t *testing.T) {
 	if _, err := Decode(nil, data); err != ErrCorrupt {
 		t.Errorf("Decode: got %v, want ErrCorrupt", err)
 	}
+
+	// The encoded varint overflows 32 bits
+	data = []byte("\xff\xff\xff\xff\xff\x00")
+
+	if _, err := DecodedLen(data); err != ErrCorrupt {
+		t.Errorf("DecodedLen: got %v, want ErrCorrupt", err)
+	}
+	if _, err := Decode(nil, data); err != ErrCorrupt {
+		t.Errorf("Decode: got %v, want ErrCorrupt", err)
+	}
 }
 
 func cmp(a, b []byte) error {


### PR DESCRIPTION
Since Go 1.1, `int` has been 64-bits on 64-bit platforms instead of
32-bits.  This patch fixes the check to make sure the uncompressed
length is at most 2^32-1 bytes.

Fixes #15