### PR TITLE
Fast skipping on uncompressible data

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -110,6 +110,12 @@ func Encode(dst, src []byte) []byte {
 		t   int // The last position with the same hash as s.
 		lit int // The start position of any pending literal bytes.
 	)
+
+	// Keep track of consecutive misses for fast skipping
+	// This is intended to roll over after 65535 misses
+	// to avoid getting out of hand.
+	var misses uint16
+
 	for s+3 < len(src) {
 		// Update the hash table.
 		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
@@ -122,9 +128,11 @@ func Encode(dst, src []byte) []byte {
 		t, *p = *p-1, s+1
 		// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
 		if t < 0 || s-t >= maxOffset || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
-			s++
+			s += 1 + int(misses>>5)
+			misses++
 			continue
 		}
+		misses = 0
 		// Otherwise, we have a match. First, emit any pending literal bytes.
 		if lit != s {
 			d += emitLiteral(dst[d:], src[lit:s])

--- a/snappy_test.go
+++ b/snappy_test.go
@@ -327,7 +327,7 @@ func downloadTestdata(b *testing.B, basename string) (errRet error) {
 	if basename == "random" {
 		rng := rand.New(rand.NewSource(27354294))
 		for i := 0; i < 1<<20; i++ {
-			_, err := f.Write([]byte{byte(rng.Intn(255))})
+			_, err := f.Write([]byte{byte(rng.Intn(256))})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This simple change will allow the encoder to skip checks if there are many consecutive match misses. This gives about 3% performance decrease on ordinary data, and in some cases up to 1%, but usually 0.1% compression loss. However, the speedup on uncompressible data is >20x.

Considering the typical use case of Snappy, I think this is a reasonable tradeoff.

I have added an additional "random data" test, as well as a benchmark that print the compression ratio.

Benchmark and size comparison:
```
benchmark               old ns/op     new ns/op     delta
Benchmark_ZFlat0-4      386453        395917        +2.45%
Benchmark_ZFlat1-4      5243380       5430495       +3.57%
Benchmark_ZFlat2-4      1219780       41927         -96.56%
Benchmark_ZFlat3-4      1219781       41859         -96.57%
Benchmark_ZFlat4-4      876567        323408        -63.11%
Benchmark_ZFlat5-4      1511665       1558024       +3.07%
Benchmark_ZFlat6-4      1297856       1317876       +1.54%
Benchmark_ZFlat7-4      1134592       1161773       +2.40%
Benchmark_ZFlat8-4      3508325       3570376       +1.77%
Benchmark_ZFlat9-4      4529655       4626386       +2.14%
Benchmark_ZFlat10-4     392659        403983        +2.88%
Benchmark_ZFlat11-4     1060197       1071549       +1.07%
Benchmark_ZFlat12-4     10637050      226674        -97.87%

benchmark               old MB/s     new MB/s     speedup
Benchmark_ZFlat0-4      264.97       258.64       0.98x
Benchmark_ZFlat1-4      133.90       129.29       0.97x
Benchmark_ZFlat2-4      100.91       2935.84      29.09x
Benchmark_ZFlat3-4      100.91       2940.62      29.14x
Benchmark_ZFlat4-4      116.82       316.63       2.71x
Benchmark_ZFlat5-4      270.96       262.90       0.97x
Benchmark_ZFlat6-4      117.18       115.40       0.98x
Benchmark_ZFlat7-4      110.33       107.75       0.98x
Benchmark_ZFlat8-4      121.64       119.53       0.98x
Benchmark_ZFlat9-4      106.38       104.15       0.98x
Benchmark_ZFlat10-4     302.01       293.55       0.97x
Benchmark_ZFlat11-4     173.85       172.01       0.99x
Benchmark_ZFlat12-4     98.58        4625.91      46.93x
```

This is the compression loss - percentage added to compressed size:

| Dataset | Loss % |
|---------|--------|
| html    | 0.04%  |
| urls    | 0.07%  |
| jpg     | 0.00%  |
| jpg_200 | 0.00%  |
| pdf     | 0.74%  |
| html4   | 0.02%  |
| txt1    | -0.06% |
| txt2    | 0.16%  |
| txt3    | 0.04%  |
| txt4    | 0.15%  |
| pb      | 0.13%  |
| gaviota | 0.00%  |
| random  | 0.00%  |

[Sheet of compression loss data](https://docs.google.com/spreadsheets/d/1DUhTU2Pbf-RZCkvz7JLghQ5o4qwKqpHNj0uhPld2I1Y/edit?usp=sharing)