### PR TITLE
Added memory recycling and optimized writes

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 This is an improved version of snappy making use of pooled memory buffers and optimized to perform less writes to the underlying writer.
+$ go get github.com/AlasdairF/snappy
 
-## Original Readme
+---- Original Readme ----
 
 The Snappy compression format in the Go programming language.
 

--- a/README
+++ b/README
@@ -1,3 +1,7 @@
+This is an improved version of snappy making use of pooled memory buffers and optimized to perform less writes to the underlying writer.
+
+## Original Readme
+
 The Snappy compression format in the Go programming language.
 
 To download and install from source:

--- a/decode.go
+++ b/decode.go
@@ -294,7 +294,7 @@ func (r *Reader) Read(p []byte) (int, error) {
 	}
 }
 
-func (r *Reader) Close() error
+func (r *Reader) Close() error {
 	pool.Return(r.decoded)
 	pool.Return(r.buf)
 	return nil

--- a/decode.go
+++ b/decode.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"github.com/AlasdairF/Pool"
 )
 
 var (
@@ -138,8 +139,8 @@ func Decode(dst, src []byte) ([]byte, error) {
 func NewReader(r io.Reader) *Reader {
 	return &Reader{
 		r:       r,
-		decoded: make([]byte, maxUncompressedChunkLen),
-		buf:     make([]byte, MaxEncodedLen(maxUncompressedChunkLen)+checksumSize),
+		decoded: pool.Get(maxUncompressedChunkLen),
+		buf:     pool.Get(maxEncodedUncompressedChunkLenPlusChecksumSize),
 	}
 }
 
@@ -291,4 +292,10 @@ func (r *Reader) Read(p []byte) (int, error) {
 			return 0, r.err
 		}
 	}
+}
+
+func (r *Reader) Close() error
+	pool.Return(r.decoded)
+	pool.Return(r.buf)
+	return nil
 }

--- a/encode.go
+++ b/encode.go
@@ -232,13 +232,11 @@ func (w *Writer) Write(p []byte) (n int, errRet error) {
 		// Compress the buffer, discarding the result if the improvement
 		// isn't at least 12.5%.
 		chunkBody := w.enc
-		chunkType := uint8(chunkTypeCompressedData)
 		chunkLen := encode(chunkBody[checksumPlusChunkHeaderSize:], uncompressed)
 		if chunkLen >= len(uncompressed) - len(uncompressed)/8 {
 			// Write the uncompressed data
 			chunkLen += 4
-			chunkType = chunkTypeUncompressedData
-			chunkBody[0] = chunkType
+			chunkBody[0] = chunkTypeUncompressedData
 			chunkBody[1] = uint8(chunkLen >> 0)
 			chunkBody[2] = uint8(chunkLen >> 8)
 			chunkBody[3] = uint8(chunkLen >> 16)
@@ -258,7 +256,7 @@ func (w *Writer) Write(p []byte) (n int, errRet error) {
 			// Write the compressed data
 			chunkBody = chunkBody[:chunkLen + checksumPlusChunkHeaderSize]
 			chunkLen += 4
-			chunkBody[0] = chunkType
+			chunkBody[0] = chunkTypeCompressedData
 			chunkBody[1] = uint8(chunkLen >> 0)
 			chunkBody[2] = uint8(chunkLen >> 8)
 			chunkBody[3] = uint8(chunkLen >> 16)

--- a/encode.go
+++ b/encode.go
@@ -14,7 +14,7 @@ import (
 const maxOffset = 1 << 15
 
 // read-only bytes
-magicChunkBytes := []byte(magicChunk)
+var magicChunkBytes = []byte(magicChunk)
 
 // emitLiteral writes a literal chunk and returns the number of bytes written.
 func emitLiteral(dst, lit []byte) int {

--- a/encode.go
+++ b/encode.go
@@ -79,6 +79,10 @@ func emitCopy(dst []byte, offset, length int) int {
 	return i
 }
 
+// Encode returns the encoded form of src. The returned slice may be a sub-
+// slice of dst if dst was large enough to hold the entire encoded block.
+// Otherwise, a newly allocated slice will be returned.
+// It is valid to pass a nil dst.
 func Encode(dst, src []byte) []byte {
 	if n := MaxEncodedLen(len(src)); len(dst) < n {
 		dst = make([]byte, n)
@@ -87,10 +91,6 @@ func Encode(dst, src []byte) []byte {
 	return dst[:d]
 }
 
-// Encode returns the encoded form of src. The returned slice may be a sub-
-// slice of dst if dst was large enough to hold the entire encoded block.
-// Otherwise, a newly allocated slice will be returned.
-// It is valid to pass a nil dst.
 func encode(dst, src []byte) (d int) {
 	// The block starts with the varint-encoded length of the decompressed bytes.
 	d = binary.PutUvarint(dst, uint64(len(src)))

--- a/snappy.go
+++ b/snappy.go
@@ -6,7 +6,7 @@
 // It aims for very high speeds and reasonable compression.
 //
 // The C++ snappy implementation is at https://github.com/google/snappy
-package snappy // import "github.com/golang/snappy"
+package snappy
 
 import (
 	"hash/crc32"

--- a/snappy.go
+++ b/snappy.go
@@ -44,11 +44,15 @@ const (
 const (
 	checksumSize    = 4
 	chunkHeaderSize = 4
+	checksumPlusChunkHeaderSize = 8 // checksumSize + chunkHeaderSize
 	magicChunk      = "\xff\x06\x00\x00" + magicBody
 	magicBody       = "sNaPpY"
 	// https://github.com/google/snappy/blob/master/framing_format.txt says
 	// that "the uncompressed data in a chunk must be no longer than 65536 bytes".
 	maxUncompressedChunkLen = 65536
+	maxEncodedUncompressedChunkLen = 76490 // maxUncompressedChunkLen + (maxUncompressedChunkLen / 6) + 32
+	maxEncodedUncompressedChunkLenPlusChecksumSize = 76494 // maxEncodedUncompressedChunkLen + checksumSize
+	maxEncodedUncompressedChunkLenPlusChecksumPlusHeaderSize = 76498 // maxEncodedUncompressedChunkLen + checksumSize + chunkHeaderSize
 )
 
 const (


### PR DESCRIPTION
I added memory pooling so buffers do not have to be reallocated.
I also optimized the Write & Encode functions so that they will now usually perform only 1 write to the underlying writer, instead of 2.
These optimizations will drastically speed up the reading and writing at the cost of around 150KB memory overhead to the user's application.
I also added some more constants to avoid unnecessary calculations.