### PR TITLE
Integrated sync.Pool + Multiple Optimizations

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -12,6 +12,9 @@ import (
 // We limit how far copy back-references can go, the same as the C++ code.
 const maxOffset = 1 << 15
 
+// read-only bytes
+var magicChunkBytes = []byte(magicChunk)
+
 // emitLiteral writes a literal chunk and returns the number of bytes written.
 func emitLiteral(dst, lit []byte) int {
 	i, n := 0, uint(len(lit)-1)
@@ -83,22 +86,27 @@ func Encode(dst, src []byte) []byte {
 	if n := MaxEncodedLen(len(src)); len(dst) < n {
 		dst = make([]byte, n)
 	}
+	d := encode(dst, src)
+	return dst[:d]
+}
 
+func encode(dst, src []byte) (d int) {
 	// The block starts with the varint-encoded length of the decompressed bytes.
-	d := binary.PutUvarint(dst, uint64(len(src)))
+	l := len(src)
+	d = binary.PutUvarint(dst, uint64(l))
 
 	// Return early if src is short.
-	if len(src) <= 4 {
-		if len(src) != 0 {
+	if l <= 4 {
+		if l != 0 {
 			d += emitLiteral(dst[d:], src)
 		}
-		return dst[:d]
+		return
 	}
 
 	// Initialize the hash table. Its size ranges from 1<<8 to 1<<14 inclusive.
 	const maxTableSize = 1 << 14
 	shift, tableSize := uint(32-8), 1<<8
-	for tableSize < maxTableSize && tableSize < len(src) {
+	for tableSize < maxTableSize && tableSize < l {
 		shift--
 		tableSize *= 2
 	}
@@ -110,7 +118,7 @@ func Encode(dst, src []byte) []byte {
 		t   int // The last position with the same hash as s.
 		lit int // The start position of any pending literal bytes.
 	)
-	for s+3 < len(src) {
+	for s+3 < l {
 		// Update the hash table.
 		b0, b1, b2, b3 := src[s], src[s+1], src[s+2], src[s+3]
 		h := uint32(b0) | uint32(b1)<<8 | uint32(b2)<<16 | uint32(b3)<<24
@@ -132,7 +140,7 @@ func Encode(dst, src []byte) []byte {
 		// Extend the match to be as long as possible.
 		s0 := s
 		s, t = s+4, t+4
-		for s < len(src) && src[s] == src[t] {
+		for s < l && src[s] == src[t] {
 			s++
 			t++
 		}
@@ -142,10 +150,10 @@ func Encode(dst, src []byte) []byte {
 	}
 
 	// Emit any final pending literal bytes and return.
-	if lit != len(src) {
+	if lit != l {
 		d += emitLiteral(dst[d:], src[lit:])
 	}
-	return dst[:d]
+	return
 }
 
 // MaxEncodedLen returns the maximum length of a snappy block, given its
@@ -180,8 +188,33 @@ func MaxEncodedLen(srcLen int) int {
 func NewWriter(w io.Writer) *Writer {
 	return &Writer{
 		w:   w,
-		enc: make([]byte, MaxEncodedLen(maxUncompressedChunkLen)),
+		enc: pool.Get().([]byte)[:maxEncodedUncompressedChunkLenPlusChecksumPlusHeaderSize],
+		buf: pool.Get().([]byte)[:maxUncompressedChunkLen],
 	}
+}
+
+func WriteOnce(writer io.Writer, p []byte) (n int, err error) {
+	if _, err = writer.Write(magicChunkBytes); err != nil {
+		return
+	}
+	w := &Writer{
+		w:   writer,
+		enc: pool.Get().([]byte)[:maxEncodedUncompressedChunkLenPlusChecksumPlusHeaderSize],
+	}
+	defer pool.Put(w.enc)
+	var uncompressed []byte
+	for len(p) > 0 {
+		if len(p) > maxUncompressedChunkLen {
+			uncompressed, p = p[:maxUncompressedChunkLen], p[maxUncompressedChunkLen:]
+		} else {
+			uncompressed, p = p, nil
+		}
+		if err = w.writeChunk(uncompressed); err != nil {
+			return
+		}
+		n += len(uncompressed)
+	}
+	return
 }
 
 // Writer is an io.Writer than can write Snappy-compressed bytes.
@@ -189,7 +222,8 @@ type Writer struct {
 	w           io.Writer
 	err         error
 	enc         []byte
-	buf         [checksumSize + chunkHeaderSize]byte
+	buf			[]byte
+	bufCursor	int
 	wroteHeader bool
 }
 
@@ -198,57 +232,129 @@ type Writer struct {
 func (w *Writer) Reset(writer io.Writer) {
 	w.w = writer
 	w.err = nil
+	w.bufCursor = 0
 	w.wroteHeader = false
 }
 
 // Write satisfies the io.Writer interface.
-func (w *Writer) Write(p []byte) (n int, errRet error) {
+func (w *Writer) Write(p []byte) (n int, err error) {
 	if w.err != nil {
 		return 0, w.err
 	}
 	if !w.wroteHeader {
-		copy(w.enc, magicChunk)
-		if _, err := w.w.Write(w.enc[:len(magicChunk)]); err != nil {
+		if _, err = w.w.Write(magicChunkBytes); err != nil {
 			w.err = err
-			return n, err
+			return
 		}
 		w.wroteHeader = true
 	}
+	var uncompressed []byte
 	for len(p) > 0 {
-		var uncompressed []byte
 		if len(p) > maxUncompressedChunkLen {
 			uncompressed, p = p[:maxUncompressedChunkLen], p[maxUncompressedChunkLen:]
 		} else {
 			uncompressed, p = p, nil
 		}
-		checksum := crc(uncompressed)
-
-		// Compress the buffer, discarding the result if the improvement
-		// isn't at least 12.5%.
-		chunkType := uint8(chunkTypeCompressedData)
-		chunkBody := Encode(w.enc, uncompressed)
-		if len(chunkBody) >= len(uncompressed)-len(uncompressed)/8 {
-			chunkType, chunkBody = chunkTypeUncompressedData, uncompressed
+		
+		// Writes with length under minUncompressedChunkLen will be copied to the buffer, over this length will be written directly as one chunk without buffering
+		// This means many small writes will be collected and written together as one single large chunk, while any large writes will be written immediately
+		// This behavior should enhance both speed and compression for small writes without sacrificing speed on large writes
+		l := len(uncompressed)
+		if l > minUncompressedChunkLen {
+			if w.bufCursor > 0 {
+				if err = w.writeChunk(w.buf[0:w.bufCursor]); err != nil { // flush
+					return
+				}
+				w.bufCursor = 0
+			}
+			if err = w.writeChunk(uncompressed); err != nil {
+				return
+			}
+		} else {
+			if l + w.bufCursor > maxUncompressedChunkLen {
+				if err = w.writeChunk(w.buf[0:w.bufCursor]); err != nil { // flush
+					return
+				}
+				w.bufCursor = 0
+			}
+			copy(w.buf[w.bufCursor:], uncompressed)
+			w.bufCursor += l
 		}
+		
+		n += l
+	}
+	return
+}
 
-		chunkLen := 4 + len(chunkBody)
-		w.buf[0] = chunkType
-		w.buf[1] = uint8(chunkLen >> 0)
-		w.buf[2] = uint8(chunkLen >> 8)
-		w.buf[3] = uint8(chunkLen >> 16)
-		w.buf[4] = uint8(checksum >> 0)
-		w.buf[5] = uint8(checksum >> 8)
-		w.buf[6] = uint8(checksum >> 16)
-		w.buf[7] = uint8(checksum >> 24)
-		if _, err := w.w.Write(w.buf[:]); err != nil {
+func (w *Writer) writeChunk(uncompressed []byte) error {
+	checksum := crc(uncompressed)
+	// Compress the buffer, discarding the result if the improvement
+	// isn't at least 12.5%.
+	chunkBody := w.enc
+	chunkLen := encode(chunkBody[checksumPlusChunkHeaderSize:], uncompressed)
+	if chunkLen >= len(uncompressed) - len(uncompressed)/8 {
+		// Write the uncompressed data
+		chunkLen += 4
+		chunkBody[0] = chunkTypeUncompressedData
+		chunkBody[1] = uint8(chunkLen >> 0)
+		chunkBody[2] = uint8(chunkLen >> 8)
+		chunkBody[3] = uint8(chunkLen >> 16)
+		chunkBody[4] = uint8(checksum >> 0)
+		chunkBody[5] = uint8(checksum >> 8)
+		chunkBody[6] = uint8(checksum >> 16)
+		chunkBody[7] = uint8(checksum >> 24)
+		if _, err := w.w.Write(chunkBody[:8]); err != nil {
 			w.err = err
-			return n, err
+			return err
 		}
+		if _, err := w.w.Write(uncompressed); err != nil {
+			w.err = err
+			return err
+		}
+	} else {
+		// Write the compressed data
+		chunkBody = chunkBody[:chunkLen + checksumPlusChunkHeaderSize]
+		chunkLen += 4
+		chunkBody[0] = chunkTypeCompressedData
+		chunkBody[1] = uint8(chunkLen >> 0)
+		chunkBody[2] = uint8(chunkLen >> 8)
+		chunkBody[3] = uint8(chunkLen >> 16)
+		chunkBody[4] = uint8(checksum >> 0)
+		chunkBody[5] = uint8(checksum >> 8)
+		chunkBody[6] = uint8(checksum >> 16)
+		chunkBody[7] = uint8(checksum >> 24)
 		if _, err := w.w.Write(chunkBody); err != nil {
 			w.err = err
-			return n, err
+			return err
 		}
-		n += len(uncompressed)
 	}
-	return n, nil
+	return nil
+}
+
+func (w *Writer) Flush() error {
+	if w.err != nil {
+		return w.err
+	}
+	if w.bufCursor > 0 {
+		w.err = w.writeChunk(w.buf[0:w.bufCursor])
+		w.bufCursor = 0
+		return w.err
+	}
+	return nil
+}
+
+func (w *Writer) Close() error {
+	if w.err == ErrClosed {
+		return nil
+	}
+	if w.bufCursor > 0 {
+		if err := w.writeChunk(w.buf[0:w.bufCursor]); err != nil {
+			w.err = err
+			return err
+		}
+	}
+	pool.Put(w.enc)
+	pool.Put(w.buf)
+	w.err = ErrClosed
+	return nil
 }

--- a/encode.go
+++ b/encode.go
@@ -298,9 +298,9 @@ func (w *Writer) writeChunk(uncompressed []byte) error {
 	chunkLen := encode(chunkBody[checksumPlusChunkHeaderSize:], uncompressed)
 	if chunkLen >= len(uncompressed) - len(uncompressed)/8 {
 		// Write the uncompressed data
-		chunkLen += 4
+		chunkLen = 4 + len(uncompressed)
 		chunkBody[0] = chunkTypeUncompressedData
-		chunkBody[1] = uint8(chunkLen >> 0)
+		chunkBody[1] = uint8(chunkLen)
 		chunkBody[2] = uint8(chunkLen >> 8)
 		chunkBody[3] = uint8(chunkLen >> 16)
 		chunkBody[4] = uint8(checksum >> 0)
@@ -320,7 +320,7 @@ func (w *Writer) writeChunk(uncompressed []byte) error {
 		chunkBody = chunkBody[:chunkLen + checksumPlusChunkHeaderSize]
 		chunkLen += 4
 		chunkBody[0] = chunkTypeCompressedData
-		chunkBody[1] = uint8(chunkLen >> 0)
+		chunkBody[1] = uint8(chunkLen)
 		chunkBody[2] = uint8(chunkLen >> 8)
 		chunkBody[3] = uint8(chunkLen >> 16)
 		chunkBody[4] = uint8(checksum >> 0)

--- a/encode.go
+++ b/encode.go
@@ -249,6 +249,10 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		w.wroteHeader = true
 	}
 	var uncompressed []byte
+	var noBuffer bool
+	if len(p) > maxUncompressedChunkLen {
+		noBuffer = true
+	}
 	for len(p) > 0 {
 		if len(p) > maxUncompressedChunkLen {
 			uncompressed, p = p[:maxUncompressedChunkLen], p[maxUncompressedChunkLen:]
@@ -260,7 +264,7 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		// This means many small writes will be collected and written together as one single large chunk, while any large writes will be written immediately
 		// This behavior should enhance both speed and compression for small writes without sacrificing speed on large writes
 		l := len(uncompressed)
-		if l > minUncompressedChunkLen {
+		if noBuffer || l > minUncompressedChunkLen {
 			if w.bufCursor > 0 {
 				if err = w.writeChunk(w.buf[0:w.bufCursor]); err != nil { // flush
 					return

--- a/snappy.go
+++ b/snappy.go
@@ -6,7 +6,7 @@
 // It aims for very high speeds and reasonable compression.
 //
 // The C++ snappy implementation is at https://github.com/google/snappy
-package snappy // import "github.com/golang/snappy"
+package snappy
 
 import (
 	"hash/crc32"

--- a/snappy.go
+++ b/snappy.go
@@ -10,6 +10,19 @@ package snappy // import "github.com/golang/snappy"
 
 import (
 	"hash/crc32"
+	"sync"
+	"errors"
+)
+
+var (
+	// ErrCorrupt reports that the input is invalid.
+	ErrCorrupt = errors.New("snappy: corrupt input")
+	// ErrTooLarge reports that the uncompressed length is too large.
+	ErrTooLarge = errors.New("snappy: decoded block is too large")
+	// ErrUnsupported reports that the input isn't supported.
+	ErrUnsupported = errors.New("snappy: unsupported input")
+	// ErrClosed is returned if Read or Write is attempted after Close
+	ErrClosed = errors.New("snappy: already closed")
 )
 
 /*
@@ -34,6 +47,7 @@ Lempel-Ziv compression algorithms. In particular:
     denoted by the next 2 bytes.
   - For l == 3, this tag is a legacy format that is no longer supported.
 */
+
 const (
 	tagLiteral = 0x00
 	tagCopy1   = 0x01
@@ -44,11 +58,17 @@ const (
 const (
 	checksumSize    = 4
 	chunkHeaderSize = 4
+	checksumPlusChunkHeaderSize = checksumSize + chunkHeaderSize
 	magicChunk      = "\xff\x06\x00\x00" + magicBody
 	magicBody       = "sNaPpY"
 	// https://github.com/google/snappy/blob/master/framing_format.txt says
 	// that "the uncompressed data in a chunk must be no longer than 65536 bytes".
 	maxUncompressedChunkLen = 65536
+	minUncompressedChunkLen = 32768 // writes under this length will be buffered
+	maxEncodedUncompressedChunkLen = 76490 // maxUncompressedChunkLen + (maxUncompressedChunkLen / 6) + 32
+	maxEncodedUncompressedChunkLenPlusChecksumSize = maxEncodedUncompressedChunkLen + checksumSize
+	maxEncodedUncompressedChunkLenPlusChecksumPlusHeaderSize = maxEncodedUncompressedChunkLen + checksumSize + chunkHeaderSize
+	maxBufSize = maxEncodedUncompressedChunkLenPlusChecksumPlusHeaderSize
 )
 
 const (
@@ -57,6 +77,13 @@ const (
 	chunkTypePadding          = 0xfe
 	chunkTypeStreamIdentifier = 0xff
 )
+
+// buffers for reading and writing are recycled using sync.Pool
+var pool = sync.Pool{
+    New: func() interface{} {
+        return make([]byte, maxBufSize)
+    },
+}
 
 var crcTable = crc32.MakeTable(crc32.Castagnoli)
 


### PR DESCRIPTION
I've made the following optimizations:

1. sync.Pool is now used to avoid reallocating buffers for both Reads and Writes. This should drastically speed up all cases where snappy is used more than once within a reasonable time. There is very little disadvantage, even if the buffers are never reused and always expire from the pool; the overhead for that is negligible.

2. I prepared the header slice of bytes to avoid it being recalculated every time.

3. I added additional constants to avoid runtime calculations.

4. I reduced the number of writes to the underlying writer from 2 to 1 on an average write by including the chunk header in the same slice of bytes as the chunk body (uncompressed chunks are still written with 2 writes, but compressed chunks are now written in 1 write.) In a normal case this would half the number of writes to the underlying writer. Writes can be expensive, especially to disk, so this should give a significant performance increase.

5. I added a buffer on the Writer which is used to group small writes into one larger write. Writes that are already over half of the max chunk size are written directly without copying to the buffer. Small writes are copied to the buffer and written together as one chunk. This was done carefully so as not to give a performance decrease in any circumstance: only small writes are buffered, large writes are written directly, and a combination of small and large writes will work fine. This feature should enhance both write speed and compression for many small writes without any decrease in performance for large writes.

6. I added the function WriteOnce, which makes encoding a single slice of bytes with snappy more efficient. This is the same but much faster than NewWriter -> Write -> Close.

7. I made a number of minor optimizations, including separating Encode into two functions, which saves some redundant calculations if encode is called via the Write function.

Note on compatibility: due to the addition of the buffer on the Writer it is now necessary to Close() the writer. This makes this version of snappy incompatible with the previous version. However, the performance gain is significant and so I believe it is reasonable to expect people to update their code. The Reader does not have to be closed, but not doing so will mean the buffers are not repooled.