### PR TITLE
Avoid allocating table on stack.

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -137,8 +137,13 @@ func (e *encoder) encode(dst, src []byte) []byte {
 		// and shift the values against this zero: add 1 on writes,
 		// subtract 1 on reads.
 		t, *p = int(*p)+tadd, int32(s+sadd)
+
+		// We calculate the proposed offset in the current buffer.
+		// If t >= s this will be negative, when converted to a uint this will always be > maxOffset.
+		offset := uint(s - t - 1)
+
 		// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-		if t < 0 || uint(s-t) >= maxOffset || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
+		if t < 0 || offset >= (maxOffset-1) || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
 			s++
 			continue
 		}

--- a/encode.go
+++ b/encode.go
@@ -83,8 +83,8 @@ var encPool = sync.Pool{New: func() interface{} { return new(encoder) }}
 // Otherwise, a newly allocated slice will be returned.
 // It is valid to pass a nil dst.
 func Encode(dst, src []byte) []byte {
-	var e = encPool.Get().(*encoder)
-	dst = e.Encode(dst, src)
+	e := encPool.Get().(*encoder)
+	dst = e.encode(dst, src)
 	encPool.Put(e)
 	return dst
 }
@@ -97,7 +97,7 @@ type encoder struct {
 	cur   int
 }
 
-func (e *encoder) Encode(dst, src []byte) []byte {
+func (e *encoder) encode(dst, src []byte) []byte {
 	if n := MaxEncodedLen(len(src)); len(dst) < n {
 		dst = make([]byte, n)
 	}
@@ -247,7 +247,7 @@ func (w *Writer) Write(p []byte) (n int, errRet error) {
 		// Compress the buffer, discarding the result if the improvement
 		// isn't at least 12.5%.
 		chunkType := uint8(chunkTypeCompressedData)
-		chunkBody := w.e.Encode(w.enc, uncompressed)
+		chunkBody := w.e.encode(w.enc, uncompressed)
 		if len(chunkBody) >= len(uncompressed)-len(uncompressed)/8 {
 			chunkType, chunkBody = chunkTypeUncompressedData, uncompressed
 		}

--- a/encode.go
+++ b/encode.go
@@ -138,7 +138,7 @@ func (e *encoder) encode(dst, src []byte) []byte {
 		// subtract 1 on reads.
 		t, *p = int(*p)+tadd, int32(s+sadd)
 		// If t is invalid or src[s:s+4] differs from src[t:t+4], accumulate a literal byte.
-		if t < 0 || s-t >= maxOffset || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
+		if t < 0 || uint(s-t) >= maxOffset || b0 != src[t] || b1 != src[t+1] || b2 != src[t+2] || b3 != src[t+3] {
 			s++
 			continue
 		}


### PR DESCRIPTION
The current implementation allocates a 64-128KB table on the stack on every call to `Encode`.

While this is reasonably fast, with a slight modification we can reuse this table across calls. This is a particular gain for the framing encoder, but even for the stateless Encode function this gives a slight speedup.

Furthermore the table is now int32, which saves 50% memory on 64 bit systems. This change does not itself affect the speed, but only the memory usage.

To be able to reuse buffers across calls to `Encode` we store the used tables in a `sync.Pool`.

The table size is now fixed. We can experiment with the size later.

```
>go test -bench=ZFlat >new.txt && benchcmp old.txt new.txt
benchmark               old ns/op     new ns/op     delta
Benchmark_ZFlat0-8      347674        334371        -3.83%
Benchmark_ZFlat1-8      4742511       4677414       -1.37%
Benchmark_ZFlat2-8      1098529       1043970       -4.97%
Benchmark_ZFlat3-8      1101338       1052056       -4.47%
Benchmark_ZFlat4-8      789205        769194        -2.54%
Benchmark_ZFlat5-8      1330515       1349258       +1.41%
Benchmark_ZFlat6-8      1145645       1139680       -0.52%
Benchmark_ZFlat7-8      1051315       988243        -6.00%
Benchmark_ZFlat8-8      3153910       3096453       -1.82%
Benchmark_ZFlat9-8      3997054       4006660       +0.24%
Benchmark_ZFlat10-8     348186        339939        -2.37%
Benchmark_ZFlat11-8     935487        925993        -1.01%

benchmark               old MB/s     new MB/s     speedup
Benchmark_ZFlat0-8      294.53       306.25       1.04x
Benchmark_ZFlat1-8      148.04       150.10       1.01x
Benchmark_ZFlat2-8      112.05       117.91       1.05x
Benchmark_ZFlat3-8      111.77       117.00       1.05x
Benchmark_ZFlat4-8      129.75       133.13       1.03x
Benchmark_ZFlat5-8      307.85       303.57       0.99x
Benchmark_ZFlat6-8      132.75       133.45       1.01x
Benchmark_ZFlat7-8      119.07       126.67       1.06x
Benchmark_ZFlat8-8      135.31       137.82       1.02x
Benchmark_ZFlat9-8      120.55       120.26       1.00x
Benchmark_ZFlat10-8     340.59       348.85       1.02x
Benchmark_ZFlat11-8     197.03       199.05       1.01x
```
