### PR TITLE
fix go test ./... when snappy is in a vendor directory

### DIFF
--- a/snappy.go
+++ b/snappy.go
@@ -6,7 +6,7 @@
 // It aims for very high speeds and reasonable compression.
 //
 // The C++ snappy implementation is at https://github.com/google/snappy
-package snappy // import "github.com/golang/snappy"
+package snappy
 
 import (
 	"hash/crc32"


### PR DESCRIPTION
Before this change:
`mycode $ go test ./...
can't load package: package mycode/vendor/github.com/golang/snappy: code in directory mycode/vendor/github.com/golang/snappy expects import "github.com/golang/snappy"`

After this, go test ./... works from the parent project.