### PR TITLE
Add a go.mod file for basic Go modules support.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/golang/snappy


### PR DESCRIPTION
In order to work well with [Go modules](https://github.com/golang/go/wiki/Modules), this package should have a `go.mod` file and semantic version tags on release versions. I have provided a rudimentary `go.mod` file here. Assuming you accept this change, and if you are willing to also `git tag v0.0.1 master` after it is merged, that would start the release history.

If the API of the package is considered stable, you could instead use `v1.0.0`, but at that point module users will expect breaking changes to increment the major version. I don't have a clear sense of how much this package is maintained, so `v0` would be a safe default for now.