### PR TITLE
Fix wrong arm64 scaled register format

### DIFF
--- a/encode_arm64.s
+++ b/encode_arm64.s
@@ -382,7 +382,7 @@ inner0:
 
 	// if load32(src, s) != load32(src, candidate) { continue } break
 	MOVW 0(R7), R3
-	MOVW (R6)(R15*1), R4
+	MOVW (R6)(R15), R4
 	CMPW R4, R3
 	BNE  inner0
 
@@ -672,7 +672,7 @@ inlineEmitCopyEnd:
 	MOVHU R3, 0(R17)(R11<<1)
 
 	// if uint32(x>>8) == load32(src, candidate) { continue }
-	MOVW (R6)(R15*1), R4
+	MOVW (R6)(R15), R4
 	CMPW R4, R14
 	BEQ  inner1
 


### PR DESCRIPTION
Arm64 does not have scaled register format, casue snappy test failed for
current go tip:

```
	$ go version
	go version devel go1.17-24875e3880 Tue Apr 20 15:14:05 2021 +0000 darwin/arm64
	$ go test
	# github.com/golang/snappy
	./encode_arm64.s:385: arm64 doesn't support scaled register format
	./encode_arm64.s:675: arm64 doesn't support scaled register format
	asm: assembly of ./encode_arm64.s failed
	FAIL	github.com/golang/snappy [build failed]
```

See https://go-review.googlesource.com/c/go/+/289589